### PR TITLE
"Download plots" data provide a PDF rather than SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Python 3+
 numpy
 pandas
 matplotlib
+svglib
+reportlab
 ```
 
 ## Installation guide:


### PR DESCRIPTION
PDFs are more convenient for users than SVG, most likely. So generate a PDF instead of SVG.