### PR TITLE
Skyline was broken if last residue different from the previous one

### DIFF
--- a/static/figure.js
+++ b/static/figure.js
@@ -611,7 +611,7 @@ class ZblobChart extends ZChart {
 			} 
 		}
 
-		// Last line segment
+		// Last line segment - add an extraneous data point to signify this
 		const last_resid = data[data.length-1].resid;
 		points.push({resid: last_resid,
 			height: data[data.length-1].domain_to_numbers});
@@ -624,9 +624,10 @@ class ZblobChart extends ZChart {
 			.attr("stroke", "grey")
 			.attr("stroke-width", 1.0)
 			.attr("d", d3.line()
-				.x(function (d) {
-					// Extend the final line segment all the way to the right
-					if(d.resid == last_resid) {
+				.x(function (d, index) {
+					// Extend the final line segment all the way to the right,
+					// if we are on that last extraneous data point
+					if(index == (points.length-1)) {
 						return x(d.resid) + x.bandwidth();
 					} else {
 						return x(d.resid);


### PR DESCRIPTION
The list of points used to generate the skyline intentionally has multiple entries that share resids, which allows for the stair-step appearance. We were checking for the last entry, in order to correctly draw the last line segment, by resid (which could be duplicated) instead of index of the array. Now we check by index.

Hopefully fixes bug #274.