### PR TITLE
Improve hydropathy amino acid scale appearance

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -56,7 +56,7 @@ td > div {
 	-webkit-appearance: none;
 	/* Override default CSS styles */
 	appearance: none;
-	width: 50%;
+	width: 100%;
 	/* Full-width */
 	height: 20px;
 	/* Specified height */
@@ -86,38 +86,14 @@ td > div {
 	opacity: 2.0;
 }
 
-/*CSS styling for the bottom slider*/
-.myslider2 {
-	-webkit-appearance: none;
-	/* Override default CSS styles */
-	appearance: none;
-	width: 50%;
-	/* Full-width */
-	height: 20px;
-	/* Specified height */
-	background: #d3d3d3;
-	/* Grey background */
-	outline: none;
-	/* Remove outline */
-	opacity: 0.7;
-	/* Set transparency (for mouse-over effects on hover) */
-	-webkit-transition: .2s;
-	/* 0.2 seconds transition on hover */
-	transition: opacity .2s;
+#hydro-labels {
+	height: 90px;
+	width: 100%;
+	position: relative;
 }
 
-/*CSS styling for the bottom slider button*/
-.myslider2::-webkit-slider-thumb {
-	-webkit-appearance: none;
-	cursor: pointer;
-	background: #007BFF;
-	border-radius: 20px;
-	width: 20px;
-	height: 20px;
-}
-
-.myslider2:hover {
-	opacity: 2.0;
-}
-
+.residue-label {
+	display: inline-block;
+	border: none;
+	width: 2em;
 }

--- a/templates/result.html
+++ b/templates/result.html
@@ -79,7 +79,7 @@ $(document).ready( function() {
 				vert_height = ">"
 				px = 0;
 			}
-			res_letters += "<div><span class= " + "residue-label" + " style= left:" + value.toString() + "%" + vert_height + key.toString() + "</span></div> "
+            res_letters += `<div class="residue-label" style="left: ${value}%; bottom: ${px}px">${key}</div>`;
 			last_pos = value;
 			document.getElementById("hydro-labels").innerHTML = res_letters;
 		}
@@ -316,7 +316,7 @@ $(document).ready( function() {
 		<div class="text-center">
 			<h6> Uniprot ID: {{ my_uni_id | safe }}</h6>
 		</div>
-		<div class="result-controls" id="result_main_container", style="width:150%">
+		<div class="result-controls" id="result_main_container">
 			<table id="results_table">
 				<col style="width:13%">
 				<col style="width:7%">
@@ -326,7 +326,7 @@ $(document).ready( function() {
 					<td><select id="hydro_scales" class="hydro_scales">
 						<option selected="selected" value="kyte_doolittle">Kyte and Doolittle</option>
 						<option value="eisenberg_weiss">Eisenberg and Weiss</option></select></td>
-						<td id="hydro-labels" style="height: 90px">
+						<td id="hydro-labels">
 					<tr><td>Hydropathy cutoff:<label style = "opacity: 0.0; display: none;">
 						<span id="cutoff_user"></span>
 					</label></td>
@@ -338,7 +338,7 @@ $(document).ready( function() {
 					</label> </td>
 					<td> <input type="number" id="domain_threshold_user_box" min="1" max={{ domain_threshold_max | safe }} value={{ domain_threshold | safe }}   step=1> 
 					</td>
-					<td> <input type="range" name="mySlider" id="domain_threshold_user_slider" min="1" max={{ domain_threshold_max | safe }} value={{ domain_threshold | safe }} class="myslider2" step=1> </td> </tr>
+					<td> <input type="range" name="mySlider" id="domain_threshold_user_slider" min="1" max={{ domain_threshold_max | safe }} value={{ domain_threshold | safe }} class="myslider1" step=1> </td> </tr>
 				</div>
 
 				<script type="text/javascript">

--- a/templates/result.html
+++ b/templates/result.html
@@ -44,46 +44,47 @@ $(document).ready( function() {
 
 	// Function to update the ticks
 	function updateHydroscaleTicks(selected_hydro_scale) {
-	// Hydropathy scales (unnormalized) if a hydropathy scale is added in the future note that these dictionaries need to be ordered from highest to lowest value
-	// Parameter: selected_hydro_scale: (str) what hydropathy scale is currently selected? 
+        // Hydropathy scales (unnormalized) if a hydropathy scale is added in the future note that these dictionaries need to be ordered from highest to lowest value
+        // Parameter: selected_hydro_scale: (str) what hydropathy scale is currently selected?
 	
-		const kyte_res = {"I": 4.500, "V": 4.200, "L": 3.800, "F": 2.800, "C": 2.500, "M": 1.900, "A": 1.800, "G": -0.400, "T": -0.700, "S": -0.800, "W": -0.900, "Y": -1.300, "P": -1.600, "H": -3.200, "N": -3.500, "B": -3.5,  "Q": -3.500, "E": -3.500, "Z": -3.5, "D": -3.500, "K": -3.900, "R": -4.500} 
+		const kyte_res = {"I": 4.500, "V": 4.200, "L": 3.800, "F": 2.800, "C": 2.500, "M": 1.900, "A": 1.800, "G": -0.400,
+            "T": -0.700, "S": -0.800, "W": -0.900, "Y": -1.300, "P": -1.600, "H": -3.200, "N": -3.500, "B": -3.5,  "Q": -3.500,
+            "E": -3.500, "Z": -3.5, "D": -3.500, "K": -3.900, "R": -4.500}
+		const eisenberg_res = {"I": 0.73, "F": 0.61, "V": 0.54, "L": 0.53, "W": 0.37, "M": 0.26, "A": 0.25, "G": 0.16,
+            "C": 0.04, "Y": 0.02, "P": -0.07, "T": -0.18, "S": -0.26, "H": -0.40, "E": -0.62, "N": -0.64, "Q": -0.69,
+            "D": -0.72, "K": -1.10, "R": -1.80}
 
-		const eisenberg_res = {"I": 0.73, "F": 0.61, "V": 0.54, "L": 0.53, "W": 0.37, "M": 0.26, "A": 0.25, "G": 0.16, "C": 0.04, "Y": 0.02, "P": -0.07, "T": -0.18, "S": -0.26, "H": -0.40, "E": -0.62, "N": -0.64, "Q": -0.69, "D": -0.72, "K": -1.10, "R": -1.80}
+        let chosen_scale;
+        if(selected_hydro_scale == "eisenberg_weiss") {
+            chosen_scale = eisenberg_res;
+        } else {
+            chosen_scale = kyte_res;
+        }
 
-	// Set initial variables
-		var res_letters = ""
-		var last_pos = 0
-		let px = 0
-	// Determine which scale we're using. Kyte-doolittle is the default because it's always how blobulation is initially calculated
-		if (selected_hydro_scale == "eisenberg_weiss") {
-			var res_dict = {}
-			for (const [key, value] of Object.entries(eisenberg_res)){
-				var pos = (value + 1.8) / 2.53 * 100
-				res_dict[key] = pos;
-			}
-		} else {
-			var res_dict = {}
-			for (const [key, value] of Object.entries(kyte_res)) {
-				var pos = ((value + 4.5) / 9.0) * 100
-				res_dict[key] = pos;
-			}
-		}
-	// Iterate through the dictionary of normalized values, assign each residue a position based on what value they fall on, and raise their vertical height if they are too close to the neighborign amino acid on the scale (their letters overlap)
-
+		let res_letters = "";
+		let last_pos = 0;
+		let px = 0;
+        let res_dict = {};
+        // Normalize hydropathy values on a 0-100 scale, to be used as x-coordinates in the UI
+        let vals = Object.values(chosen_scale);
+        // Math.max/min don't take arrays, so we have to extract the values with the "..." operator
+        let min_val = Math.min(...vals);
+        let span = Math.max(...vals) - min_val;
+        for (const [key, value] of Object.entries(chosen_scale)) {
+            res_dict[key] = (value - min_val) / span * 100;
+        }
+	    // Iterate through the dictionary of normalized values, assign each residue a position based on what value they fall on, and raise their vertical height if they are too close to the neighborign amino acid on the scale (their letters overlap)
 		for (const [key, value] of Object.entries(res_dict)){
 			if (last_pos == value || last_pos - 1.5 <= value) {
-				vert_height = ";bottom:" + px.toString() + "px>"
 				px += 14
 			} else {
-				vert_height = ">"
 				px = 0;
 			}
             res_letters += `<div class="residue-label" style="left: ${value}%; bottom: ${px}px">${key}</div>`;
 			last_pos = value;
-			document.getElementById("hydro-labels").innerHTML = res_letters;
 		}
-	} 
+    	document.getElementById("hydro-labels").innerHTML = res_letters;
+	}
 
 	// Call the function
 	updateHydroscaleTicks(sel_hydro_scale)


### PR DESCRIPTION
This PR provides 1) a cosmetic improvement to the amino acid residue hydropathy scale and 2) cleans up the code a little bit such that the minimum and maximum hydropathy values are not hard-coded but instead calculated.

We should still consider not hard-coding the hydropathy schemes themselves (i.e. Eisenberg vs Kyte) in the code. From a software design perspective, it should be possible to add more schemes by editing some data file rather than modifying the code.