### PR TITLE
Download data iss449

### DIFF
--- a/blobulator/compute_blobs.py
+++ b/blobulator/compute_blobs.py
@@ -462,7 +462,7 @@ def clean_df(df):
     del df["P_diagram"]
     del df["uversky_color"]
     del df["disorder_color"]
-    del df["hydropathy_3_window_mean"] 
+    #del df["hydropathy_3_window_mean"] 
     del df["hydropathy_digitized"] 
     #del df["hydropathy"]
     del df["charge"]

--- a/blobulator/compute_blobs.py
+++ b/blobulator/compute_blobs.py
@@ -489,7 +489,7 @@ def clean_df(df):
                             'hydropathy': 'Normalized_hydropathy',
                             'hydropathy_3_window_mean': 'Smoothed_Hydropathy',
                             'N': 'blob_length'})
-    df['Kyte-Doolittle_hydropathy'] = df['Normalized_Kyte-Doolittle_hydropathy']*9-4.5
+    #df['Kyte-Doolittle_hydropathy'] = df['Normalized_Kyte-Doolittle_hydropathy']*9-4.5
 
     return df
 

--- a/blobulator/compute_blobs.py
+++ b/blobulator/compute_blobs.py
@@ -486,7 +486,8 @@ def clean_df(df):
                             'h_numerical_enrichment': 'dSNP_enrichment', 
                             'blob_charge_class': 'Blob_Das-Pappu_Class', 
                             'U_diagram': 'Uversky_Diagram_Score', 
-                            'hydropathy': 'Normalized_Kyte-Doolittle_hydropathy',
+                            'hydropathy': 'Normalized_hydropathy',
+                            'hydropathy_3_window_mean': 'Smoothed_Hydropathy',
                             'N': 'blob_length'})
     df['Kyte-Doolittle_hydropathy'] = df['Normalized_Kyte-Doolittle_hydropathy']*9-4.5
 

--- a/blobulator/compute_blobs.py
+++ b/blobulator/compute_blobs.py
@@ -462,13 +462,30 @@ def clean_df(df):
     del df["P_diagram"]
     del df["uversky_color"]
     del df["disorder_color"]
-    #del df["hydropathy_3_window_mean"] 
-    del df["hydropathy_digitized"] 
-    #del df["hydropathy"]
+    del df["hydropathy_digitized"]
     del df["charge"]
     del df["domain_to_numbers"]
     df['resid'] = df['resid'].astype(int)
-    df = df[[ 'resid', 'seq_name', 'window', 'm_cutoff', 'domain_threshold', 'N', 'H', 'min_h', 'blobtype', 'domain', 'blob_charge_class', 'NCPR', 'f+', 'f-', 'fcr', 'U_diagram', 'h_numerical_enrichment', 'disorder', 'hydropathy']]
+    df = df[[ 'resid',
+             'seq_name',
+             'window',
+             'm_cutoff',
+             'domain_threshold',
+             'N',
+             'H',
+             'min_h',
+             'blobtype',
+             'domain',
+             'blob_charge_class',
+             'NCPR',
+             'f+',
+             'f-',
+             'fcr',
+             'U_diagram',
+             'h_numerical_enrichment',
+             'disorder',
+             'hydropathy',
+             'hydropathy_3_window_mean']]
     df = df.rename(columns={'seq_name': 'Residue_Name', 
                             'resid': 'Residue_Number', 
                             'disorder': 'Blob_Disorder', 


### PR DESCRIPTION
Addressing issue #449; restore missing smoothed data and, incidentally, remove references to kyte-doolittle

1. Old version deleted the hydropathy_3_window_mean column. This branch doesn't.
2. [Side-effect] Old version had a "Kyte-Doolittle" column name. This is no longer the case for other hydropathy scales. 