### PR TITLE
HOT FIX: check if API calls are returning something

### DIFF
--- a/website/blobulation.py
+++ b/website/blobulation.py
@@ -6,9 +6,9 @@ import sys
 sys.path.insert(0, '../library/')
 
 from user_input_form import InputForm
-from amino_acids import properties_hydropathy
-from compute_blobs import (compute, clean_df)
-from compute_snps import pathogenic_snps
+from blobulator.amino_acids import properties_hydropathy
+from blobulator.compute_blobs import (compute, clean_df)
+from blobulator.compute_snps import pathogenic_snps
 
 import pandas as pd
 import numpy as np
@@ -34,7 +34,8 @@ from reportlab.graphics import renderPDF
 
 from importlib import reload
 
-
+import requests
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 template_dir = os.path.abspath('../website/templates')
 app = Flask(__name__, template_folder=template_dir)
@@ -49,6 +50,9 @@ REQUEST_URL_snp = "https://www.ebi.ac.uk/proteins/api/variation"
 REQUEST_URL_features = "https://www.ebi.ac.uk/proteins/api/features"
 REQUEST_UNIPROT_ID_FROM_ENSEMBL = "https://www.uniprot.org/uploadlists/"
 REQUEST_URL_coordinates = "https://www.ebi.ac.uk/proteins/api/coordinates"
+
+# Wait this many seconds, max
+REQUEST_TIMEOUT = 10
 
 @app.route("/", methods=["GET", "POST"])
 def index():
@@ -92,14 +96,6 @@ def index():
                 else:
                     original_accession = ""
 
-            try:
-                response_d2p2 = requests.get(
-                    f'http://d2p2.pro/api/seqid/["{user_uniprot_id}"]'
-                )
-                data_d2p2 = response_d2p2.json()
-            except:
-                data_d2p2 = {user_uniprot_id: []}
-
             # get the sequence and its name from uniprot database, perform error checks
             uniprot_params = {
                 "offset": 0,
@@ -107,50 +103,60 @@ def index():
                 "consequencetype": "missense",
                 "accession": user_uniprot_id,
             }
-            try:
-                get_sequence = requests.get(
-                    REQUEST_URL_features,
-                    params=uniprot_params,
-                    headers={"Accept": "application/json"},
-                )
-            except ConnectionError:
-                return render_template("error.html",
-                    title="Unable to connect to UniProt server",
-                    message="""There is probably an intermittent network error from our server to theirs.
-                    If the UniProt server is down then this service won't work either.
-                    Please try again later.""")
-            seq_file = get_sequence.json()
 
-            if 'errorMessage' in seq_file:
-                return render_template("error.html",
-                    title="UniProt server returned an error",
-                    message=f"""The UniProt server said: {', '.join(seq_file['errorMessage'])}""")
+            # We define a nested function that we'll call below using a thread pool
+            def fetch_json(args):
+                tag, url, params = args
+                try:
+                    data = requests.get(
+                        url,
+                        params=params,
+                        headers={"Accept": "application/json"},
+                        timeout=REQUEST_TIMEOUT # NB: This is where we tweak the timeout. 
+                    )
+                except:
+                    return tag, None
+                
+                return tag, data.json()
 
-            get_snp = requests.get(
-                REQUEST_URL_snp,
-                params=uniprot_params,
-                headers={"Accept": "application/json"},
-            )
-            # HTTP status code 200 means the request was successful
-            if get_snp.status_code != 200:
-                return render_template("error.html",
-                    title="Error getting SNP from UniProt",
-                    message="""There was an error retrieving SNP data from UniProt""")
+            # We have a list of request URLs and parameters. Each one is annotated by a "tag" which is just the first
+            # string in each tuple. We'll use this tag to identify which result data goes with what request
+            fetch_args = [
+                ('D2P2', f'http://d2p2.pro/api/seqid/["{user_uniprot_id}"]', []),
+                ('Feature', REQUEST_URL_features, uniprot_params),
+                ('SNP', REQUEST_URL_snp, uniprot_params),
+                ('Coordinates', REQUEST_URL_coordinates, uniprot_params),
+            ]
 
-            seq_file_snp = get_snp.json()
+            # The ThreadPoolExecutor has a submit method that dispatches the function we specified (fetch_json)
+            # multiple times concurrently. It immediately returns a "future" which gets resolved by the as_completed
+            # method, which I guess returns the next available result when it is called, or blocks waiting for one
+            fetched_data = {}
+            with ThreadPoolExecutor() as executor:
+                futures = [executor.submit(fetch_json, args) for args in fetch_args]
+                for future in as_completed(futures):
+                    try:
+                        tag, data = future.result()
+                        fetched_data[tag] = data
+                    except ValueError as e:
+                        # print(f"Task generated exception: {e}")
+                        fetched_data[tag] = None
+                
+            # At this point fetched data is full of either our data, or Nones for each thing we called
+            data_d2p2 = fetched_data['D2P2']
+            seq_file = fetched_data['Feature']
+            seq_file_snp = fetched_data['SNP']
+            seq_file_coords = fetched_data['Coordinates']
 
+            # Now we can process the fetched data
             if seq_file_snp:
                 snps_json = pathogenic_snps(seq_file_snp[0]["features"]) #filters the disease causing SNPs
             else:
                 snps_json = "[]"
             my_seq = seq_file[0]["sequence"]
 
-            if (
-                user_uniprot_id not in data_d2p2
-                or len(data_d2p2[user_uniprot_id]) == 0
-            ):
+            if (data_d2p2 is None) or (user_uniprot_id not in data_d2p2 or len(data_d2p2[user_uniprot_id]) == 0):
                 disorder_residues = [0]
-
             else:
                 try:
                     disorder_file = data_d2p2[user_uniprot_id][0][2]["disorder"]["disranges"] #filters the disorder residues from d2p2, PV2 predictor
@@ -176,19 +182,6 @@ def index():
                 user_uniprot_name = ''
                 user_uniprot_entry = ''
 
-            get_coords = requests.get(
-                REQUEST_URL_coordinates,
-                params=uniprot_params,
-                headers={"Accept": "application/json"},
-            )
-
-            # HTTP status code 200 means the request was successful
-            if get_coords.status_code != 200:
-                return render_template("error.html",
-                    title="Error getting genomic coordinates from UniProt",
-                    message="""There was an error retrieving SNP data from UniProt""")
-
-            seq_file_coords = get_coords.json()
             try:
                 gn_chrom = seq_file_coords[0]['gnCoordinate'][0]['genomicLocation']['chromosome']
                 gn_start = seq_file_coords[0]['gnCoordinate'][0]['genomicLocation']['exon'][0]['genomeLocation']['begin']['position']

--- a/website/blobulation.py
+++ b/website/blobulation.py
@@ -148,11 +148,22 @@ def index():
             seq_file_snp = fetched_data['SNP']
             seq_file_coords = fetched_data['Coordinates']
 
+            if 'errorMessage' in seq_file:
+                return render_template("error.html",
+                    title="UniProt server returned an error",
+                    message=f"""The UniProt server said: {', '.join(seq_file['errorMessage'])}""")
+            
+            if 'errorMessage' in seq_file_snp:
+                return render_template("error.html",
+                    title="UniProt server returned an error",
+                    message=f"""The UniProt server said: {', '.join(seq_file_snp['errorMessage'])}""")
+
             # Now we can process the fetched data
             if seq_file_snp:
                 snps_json = pathogenic_snps(seq_file_snp[0]["features"]) #filters the disease causing SNPs
             else:
                 snps_json = "[]"
+
             my_seq = seq_file[0]["sequence"]
 
             if (data_d2p2 is None) or (user_uniprot_id not in data_d2p2 or len(data_d2p2[user_uniprot_id]) == 0):


### PR DESCRIPTION
If an API is down, skip it and provide the data we can get.

If and only if the checklist is complete, main can be pulled into production. Close the issue.

For each of the following, do blobs change height and color as expected:

- [x] When the mutation button is checked with a SNP
- [x] After adjusting the hydropathy slider
- [x] After adjusting the blob size slider
- [x] After adjusting the hydropathy numerical input
- [x] After adjusting the blob size numerical input
- [x] After clicking the hydropathy up and down buttons
- [x] After clicking the blob size up and down buttons

- [x] Check the download plots button
- [x] Check the download data button



- [x] Check that website links lead to the expected papers and websites
- [x] Check multiple SNP residues and make sure that they update correctly after selecting a new SNP
- [x] Run current regression tests with an introduced mutation.
- [x] Check uniprot and ensemble IDs for both a legitimate and false ID. Make sure that the expected protein is blobulated, and a valid error is shown in the case of a false ID
- [x] When the results page is loaded (on a non-full screen browser window) are all plots and “i” icons visible?
- [x] For each track, are all bars visible?
- [x] Load a large protein, does the browser load within 1 minute?
- [x] Check links for SNP triangles, make sure they lead to the expected website
- [x] Does everything on both the result and home pages look aligned?
- [x] When clickable elements are selected, do they look as expected?
- [ ] Does the terminal output anything when blobulation occurs?
- [x] Are SNP triangles centered over the correct residue?
- [x] Does the skyline update around the correct residues?
- [x] Does the result controls panel stay at the top of the page when scrolling?
- [x] When zooming, check that all figures update, resid labels are legible, and the skyline updates correctly.
- [x] Is the control panel correctly sized?
- [x] Do all tabs contain their expected content?

- [x] Blobulate the sequence GSGPPGPPGPPGPPGARGQAGVMGFPGPPGPPGPPGRAPTDQHIKQVCMRVIQEHFAEMAASLKRPDSGAT, and check that the smoothed kyte-doolittle hydropathies match those given by https://www.ebi.ac.uk/Tools/seqstats/emboss_pepinfo/

- [x] Does the NCPR coloring match that of the production site?
