### PR TITLE
HOTFIX: richFig wasn't being updated properly

### DIFF
--- a/website/templates/result.html
+++ b/website/templates/result.html
@@ -95,23 +95,21 @@ $(document).ready( function() {
 		//iterate over all figures in figs and update them
 		for (let [key, value] of Object.entries(figs)) { 
 			if (key == "richFig") {
-				if (sel_hydro_scale != 'kyte_doolittle') {
+				if (sel_hydro_scale != 'kyte_doolittle' && !document.getElementById("overlay")) {
 					value.add_warning_overlay()
-                    console.log("add warning")
 				}
-				else {
+				else if (sel_hydro_scale == 'kyte_doolittle' && document.getElementById("overlay")) {
 					value.remove_warning_overlay()
-                    console.log("remove warning")
 				}
 			}
-			else {
-				try {
-					value.update_bars(data);
-				}
-				catch {
-					console.log("Failed to update: " + key)
-				}
-			}
+
+            try {
+                value.update_bars(data);
+            }
+            catch {
+                console.log("Failed to update: " + key)
+            }
+			
 		}
 	}
 


### PR DESCRIPTION
# Overview:
richFig wasn't being updated properly
BONUS: the warning message for other hydropathy plots was being made repeatedly.
fixes #558 

# To-dos
- [x]  always update plots even if key=='richFig' 
- [x]  only add the warning iff no warning exists
- [x]  only try to remove the warning if a warning exists