### PR TITLE
550 ligand excluder

### DIFF
--- a/VMD_scripts/blobulation.tcl
+++ b/VMD_scripts/blobulation.tcl
@@ -246,7 +246,7 @@ proc ::blobulator::blobulateSelection {MolID lMin H select dictInput} {
 	
 		}
 		
-		return $chainBlobs
+		return 
 }
 
 #
@@ -846,10 +846,10 @@ proc ::blobulator::blobUser2AssignSelector { blob2 MolID chainList} {
 	
 	}
 	
-	if {$::blobulator::framesOn == 1} {
+	
 		set numOfFrames [molinfo $molid get numframes]
 		::blobulator::blobTrajUser2 $numOfFrames $blob2 $MolID
-	}  
+	
 }
 
 #
@@ -885,10 +885,10 @@ proc ::blobulator::blobUser2Assign { blob2 MolID } {
 	
 	} 
 	
-	if {$::blobulator::framesOn == 1} {
+	
 		set numOfFrames [molinfo $molid get numframes]
 		::blobulator::blobTrajUser2 $numOfFrames $blob2 $MolID
-	} 
+	
 }
 
 

--- a/VMD_scripts/blobulation.tcl
+++ b/VMD_scripts/blobulation.tcl
@@ -6,6 +6,7 @@
 namespace eval ::blobulator:: {
 	variable framesOn 0
 	variable framesTotal 1
+	variable sorted {}
 } 
 atomselect macro canonAA {resname ALA ARG ASN ASP CYS GLN GLU GLY HIS HID HIE ILE LEU LYS MET PHE PRO SET THR TRP TYR VAL}
 
@@ -189,18 +190,18 @@ proc ::blobulator::blobulateSelection {MolID lMin H select dictInput} {
 		set chainBlobs {}
 		set chainBlobIndex {}
 		set chainBlobGroup {}
-		set sorted [::blobulator::getSelect $MolID $select]
-		foreach s $sorted {
+		set ::blobulator::sorted [::blobulator::getSelect $MolID $select]
+		foreach s $::blobulator::sorted {
 			set check [atomselect $nocaseMolID "alpha and protein and canonAA and chain $s"]
 			if {[llength [$check get resname]] < 3} {
-				set idx [lsearch $sorted $s]
-				set sorted [lreplace $sorted $idx $idx]
+				set idx [lsearch $::blobulator::sorted $s]
+				set ::blobulator::sorted [lreplace $::blobulator::sorted $idx $idx]
 				
 			}
 			$check delete
 		}
-		for {set i 0} {$i < [llength $sorted] } { incr i} {
-			set singleChain [lindex $sorted $i] 
+		for {set i 0} {$i < [llength $::blobulator::sorted] } { incr i} {
+			set singleChain [lindex $::blobulator::sorted $i] 
 			set chainReturn [::blobulator::blobulateChain $MolID $lMin $H $singleChain $usedDictionary]
 				if { $chainReturn == -1} {
 				break
@@ -239,8 +240,8 @@ proc ::blobulator::blobulateSelection {MolID lMin H select dictInput} {
 
 		if {$chainBlobs != -1} {
 		
-		::blobulator::blobUserAssignSelector $chainBlobs $MolID $sorted
-		::blobulator::blobUser2AssignSelector $chainBlobIndex $MolID $sorted
+		::blobulator::blobUserAssignSelector $chainBlobs $MolID $::blobulator::sorted
+		::blobulator::blobUser2AssignSelector $chainBlobIndex $MolID $::blobulator::sorted
 		
 	
 	
@@ -917,7 +918,7 @@ proc ::blobulator::blobTrajUser2 {frames blob2 MolID} {
 	
 
 	
-	set sel2 [atomselect $MolID "protein and canonAA"]
+	set sel2 [atomselect $MolID "protein and canonAA and chain $::blobulator::sorted"]
 	for {set i 0} { $i <= $frames} {incr i} {
 		
 		$sel2 frame $i

--- a/VMD_scripts/blobulation.tcl
+++ b/VMD_scripts/blobulation.tcl
@@ -138,7 +138,6 @@ proc ::blobulator::blobulate {MolID lMin H dictInput} {
 proc ::blobulator::blobulateChain {MolID lMin H Chain usedDictionary} {
 	source normalized_hydropathyscales.tcl
 	set sequence [::blobulator::getSequenceChain $MolID $Chain]
-	puts [llength $sequence]
 	set hydroS [::blobulator::hydropathyScores $usedDictionary $sequence]
 	if {$hydroS == -1} {
 		return -1

--- a/VMD_scripts/blobulation.tcl
+++ b/VMD_scripts/blobulation.tcl
@@ -8,7 +8,7 @@ namespace eval ::blobulator:: {
 	variable framesTotal 1
 	variable sorted {}
 } 
-atomselect macro canonAA {resname ALA ARG ASN ASP CYS GLN GLU GLY HIS HID HIE ILE LEU LYS MET PHE PRO SET THR TRP TYR VAL}
+atomselect macro canonAA {resname ALA ARG ASN ASP CYS GLN GLU GLY HIS HID HIE ILE LEU LYS MET PHE PRO SER THR TRP TYR VAL}
 
 #
 #	The overarching proc, users use this to run program
@@ -138,6 +138,7 @@ proc ::blobulator::blobulate {MolID lMin H dictInput} {
 proc ::blobulator::blobulateChain {MolID lMin H Chain usedDictionary} {
 	source normalized_hydropathyscales.tcl
 	set sequence [::blobulator::getSequenceChain $MolID $Chain]
+	puts [llength $sequence]
 	set hydroS [::blobulator::hydropathyScores $usedDictionary $sequence]
 	if {$hydroS == -1} {
 		return -1

--- a/VMD_scripts/blobulation.tcl
+++ b/VMD_scripts/blobulation.tcl
@@ -192,10 +192,10 @@ proc ::blobulator::blobulateSelection {MolID lMin H select dictInput} {
 		set sorted [::blobulator::getSelect $MolID $select]
 		foreach s $sorted {
 			set check [atomselect $nocaseMolID "alpha and protein and canonAA and chain $s"]
-			if {[llength [$check get resname]] < 1} {
+			if {[llength [$check get resname]] < 3} {
 				set idx [lsearch $sorted $s]
 				set sorted [lreplace $sorted $idx $idx]
-				puts $sorted
+				
 			}
 			$check delete
 		}
@@ -264,7 +264,7 @@ proc ::blobulator::checker {MolID lMin H} {
 	set nocaseMolID [string tolower $MolID]
 	set sel [atomselect $nocaseMolID "alpha and protein and canonAA"]
 	set sorted [lsort -unique [$sel get chain]]
-	puts $sorted
+	
 	if {[molinfo $MolID get numframes] > 1} {
 		set ::blobulator::framesOn 1
 		set ::blobulator::framesTotal [molinfo $MolID get numframes]
@@ -795,7 +795,7 @@ proc ::blobulator::blobUserAssignSelector {blob1 MolID chainList} {
 	for {set j 1} { $j <= 3 } {incr j} {
 		set sel [atomselect $molid "user $j"]
 		set residues [$sel get resid]
-		puts $residues
+		
 		$sel delete
 		if {[llength $residues] > 1} {
 			


### PR DESCRIPTION
## Overview
This PR allows the blobulator plugin to exclude any nonhuman canonical amino acids.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Associated Issues
fixes #550 

## To-dos
- [x] Create macro for all human canonical amino acids
