### PR TITLE
424 GitHub icon addition to website

### DIFF
--- a/website/templates/common-tablist.html
+++ b/website/templates/common-tablist.html
@@ -10,3 +10,10 @@
 <li class="nav-item">
     <a href="#home" id="home-tab" class="nav-link" data-toggle="tab">New Query</a>
 </li>
+
+<li>
+<a href="https://github.com/BranniganLab/blobulator" target="_blank" rel="noopener noreferrer">
+  <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" width="30">
+</a>
+  </a>
+</li>

--- a/website/templates/common-tablist.html
+++ b/website/templates/common-tablist.html
@@ -1,3 +1,10 @@
+
+<li>
+    <a href="https://github.com/BranniganLab/blobulator" target="_blank" rel="noopener noreferrer">
+  <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" 
+        width="30" style="position: relative; top: 5px;">
+    </a>
+</li>
 <li class="nav-item">
     <a href="#about" id="about-tab" class="nav-link" data-toggle="tab">About</a>
 </li>
@@ -11,9 +18,3 @@
     <a href="#home" id="home-tab" class="nav-link" data-toggle="tab">New Query</a>
 </li>
 
-<li>
-<a href="https://github.com/BranniganLab/blobulator" target="_blank" rel="noopener noreferrer">
-  <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" width="30">
-</a>
-  </a>
-</li>


### PR DESCRIPTION
## Overview
Added a GitHub icon to the tabs on the website which redirects to the GitHub page

## Type of Change
- [?] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Associated Issues
- Link to and summary of issue(s) that this PR addresses

## To-dos
- [ ] Rundown of changes that have been made
<img width="774" alt="Screenshot 2025-03-03 at 3 25 53 PM" src="https://github.com/user-attachments/assets/26b6388a-f842-4f22-bef7-ef8638e5774d" />
