### PR TITLE
Fixing error that occurs if alphafold structure isn't returned when ID entry is used

### DIFF
--- a/website/blobulation.py
+++ b/website/blobulation.py
@@ -162,17 +162,15 @@ def index():
                 temporary_pdb_file = f"{user_uniprot_id}_alphafold.pdb"
                 with open(temporary_pdb_file, "w") as f:
                     f.write(alphafold_pdb)
+                io = PDBIO()
+                structure = PDBParser().get_structure('structure', temporary_pdb_file)
+                chain = "A"
+                my_seq, shift, saved_chain, pdb_string = extract_chain(chain, temporary_pdb_file, io, structure)
+                os.remove(f"{user_uniprot_id}_alphafold.pdb")
             else:
                 print(f"\nAlphaFold structure not found for {user_uniprot_id}")
+                pdb_string = ''
 
-            io = PDBIO()
-            structure = PDBParser().get_structure('structure', temporary_pdb_file)
-            chain = "A"
-
-            my_seq, shift, saved_chain, pdb_string = extract_chain(chain, temporary_pdb_file, io, structure)
-            
-            # Cleanup
-            os.remove(f"{user_uniprot_id}_alphafold.pdb")
 
             if seq_file is None:
                 return render_template("error.html",


### PR DESCRIPTION
## Overview
Moved alphafold pdb processing so that it only triggers if there's an alphafold pdb to process

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Associated Issues
- issue #666 

## To-dos
- [x] moved alphafold pdb processing under conditional, and creating an empty string if it returns nothing, allowing the uniprot id result page to still display even if an alphafold structure isn't returned