### PR TITLE
Documentation tab updates

### DIFF
--- a/website/templates/common-tabcontent.html
+++ b/website/templates/common-tabcontent.html
@@ -73,7 +73,7 @@
     <h4 class="mt-2">Tunable Items on the Results Page</h4>
     <button class="accordion"> &#10133 Choosing a Hydropathy Scale</button>
     <div class="panel">
-    <p>The defult scale used for the initial blobulation is the Kyte Doolittle hydropathy scale, but other scales can be selected from the dropdown menu. Changing the scale will update the clickable amino acid letters above the hydropathy cutoff slider.</p>
+    <p>The default scale used for the initial blobulation is the Kyte Doolittle hydropathy scale, but other scales can be selected from the dropdown menu. Changing the scale will update the clickable amino acid letters above the hydropathy cutoff slider.</p>
     </div>
     <button class="accordion"> &#10133 Adjusting Hydropathy Cutoff</button>
     <div class="panel">
@@ -113,7 +113,7 @@
     </div>
     <button class="accordion">&#10133 Blobs colored according to Uversky diagram</button>
     <div class="panel">
-    <p>This fourth outputted visualization shows the blobs according to their positions on the <a href="https://pubmed.ncbi.nlm.nih.gov/11025552/" target="_blank"> Uversky diagram </a>, where the line between ordered and disordered is plotted. Calculated negative values (represented in orange) are more ordered and positive values (shown in blue) are more disordered.</p>
+    <p>This fourth outputted visualization shows the blobs according to their positions on the <a href="https://pubmed.ncbi.nlm.nih.gov/11025552/" target="_blank"> Uversky diagram</a>, where the line between ordered and disordered is plotted. Calculated negative values (represented in orange) are more ordered and positive values (shown in blue) are more disordered.</p>
     </div>
     <button class="accordion">&#10133 Blobs colored according to dSNP enrichment</button>
     <div class="panel">
@@ -136,19 +136,19 @@
     <li><strong>Minimum_Blob_Length:</strong> The minimum blob length used during blobulation (integer greater than 0)</li>
     <li><strong>blob_length:</strong> The length of the residue's blob</li>
     <li><strong>Normalized_Mean_Blob_Hydropathy:</strong> The normalized mean hydropathy of the residue's blob</li>
-    <li><strong>Min_Blob_Hydropathy:</strong>The minimum hydropathy cutoff at which all residues in this blob remain classified as in the same blob.</li>
+    <li><strong>Min_Blob_Hydropathy:</strong>The minimum hydropathy cutoff at which all residues in this blob remain classified as in the same blob</li>
     <li><strong>Blob_Type:</strong> The one-letter blob code (h = hydropathic, p = polar/hydrophilic, s = short hydrophilic)</li>
-    <li><strong>Blob_Index_Number:</strong> Indices which distinguish blobs. For example, h1 is the first hydrophobic blob. h1a and h1b refer to two halves of a blob separated by a short hydrophilic blob.</li>
+    <li><strong>Blob_Index_Number:</strong> Indices which distinguish blobs (for example - h1 is the first hydrophobic blob, h1a and h1b refer to two halves of a blob separated by a short hydrophilic blob)</li>
     <li><strong>Blob_Das-Pappu_Class:</strong> Blob scored by Das–Pappu globularity (1 = globular, 2 = Janus/boundary, 3 = polar, 4 = polycation, 5 = polyanion)</li>
     <li><strong>Blob_NCPR:</strong> Net charge per residue of the blob</li>
     <li><strong>Fraction_of_Positively_Charged_Residues:</strong> FPC = N(positively charged residues) / N(residues)</li>
     <li><strong>Fraction_of_Negatively_Charged_Residues:</strong> FNC = N(negatively charged residues) / N(residues)</li>
     <li><strong>Fraction_of_Charged_Residues:</strong> FCR = FPC + FNC</li>
-    <li><strong>Uversky_Diagram_Score:</strong> Distance from the Uversky–Gillespie–Fink globular/disordered cutoff. See <a href="https://pubmed.ncbi.nlm.nih.gov/11025552/">PMID: 11025552</a>.</li>
-    <li><strong>dSNP_enrichment:</strong> Predicted enrichment of disease-causing SNPs. See <a href="https://doi.org/10.1073/pnas.2116267119>"> DOI 10.1073/pnas.2116267119</a>.</li>
-    <li><strong>Blob_Disorder:</strong> Mean expected disorder score as provided by D2P2. See <a href="https://doi.org/10.1093/nar/gks1226">DOI: 10.1093/nar/gks1226</a>.</li>
+    <li><strong>Uversky_Diagram_Score:</strong> Distance from the Uversky–Gillespie–Fink globular/disordered cutoff (see <a href="https://pubmed.ncbi.nlm.nih.gov/11025552/">PMID: 11025552)</a></li>
+    <li><strong>dSNP_enrichment:</strong> Predicted enrichment of disease-causing SNPs (see <a href="https://doi.org/10.1073/pnas.2116267119>"> DOI 10.1073/pnas.2116267119)</a></li>
+    <li><strong>Blob_Disorder:</strong> Mean expected disorder score as provided by D2P2 (see <a href="https://doi.org/10.1093/nar/gks1226">DOI: 10.1093/nar/gks1226)</a></li>
     <li><strong>Normalized_hydropathy:</strong> Each individual residue's hydropathy normalized to the range 0–1</li>
-    <li><strong>Smoothed_Hydropathy:</strong> Each residue's hydropathy smoothed using the residues immediately adjacent to it (displayed on the "Smoothed hydropathy per residue track").</li>
+    <li><strong>Smoothed_Hydropathy:</strong> Each residue's hydropathy smoothed using the residues immediately adjacent to it (displayed on the "Smoothed hydropathy per residue track")</li>
     </ul>
     </div>
 


### PR DESCRIPTION
## Overview
Updating the Documentation tab - restructuring and adding new content

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Associated Issues
- issue #700 

## To-dos
- [x] Restructure the order of elements in Documentation tab 
- [x] Add hydropathy scale choice information
- [x] Add explanation of the columns for the Downloading Data section
- [x] Remove extra SNPs and mutations tab, add that link to database is available when hovering
