### PR TITLE
removed 'For example' in the hydropathy cutoff info icon

### DIFF
--- a/website/templates/result.html
+++ b/website/templates/result.html
@@ -49,7 +49,7 @@ $(document).ready( function() {
 			aria-hidden="true">&times;</a><br>
 			The hydropathy cutoff number, denoted as H<sup>*</sup>, represents the threshold
 			at which a residue is considered hydrophobic or non-hydrophobic based on its
-			hydropathy score. For example, if a residue has a hydropathy score above the
+			hydropathy score. If a residue has a hydropathy score above the
 			threshold, it will be considered hydrophobic.
 		`
 	});


### PR DESCRIPTION
## Overview
Slightly edited the info caption for the 'Hydropathy cutoff' on the Blobulator results page

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [X] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Associated Issues
- https://github.com/BranniganLab/blobulator/issues/704

## To-dos
- [X] Edit content in the info icon popover
