### PR TITLE
changed hydropathy scales to hydrophobicity scales

### DIFF
--- a/website/templates/result.html
+++ b/website/templates/result.html
@@ -86,7 +86,7 @@ $(document).ready( function() {
 			type="button"
 			class="close"
 			aria-hidden="true">&times;</a><br>
-			The hydrophobicity scale used in blobulation dictates the hydropathy of an amino acid. Hydropathy scales include:
+			The hydrophobicity scale used in blobulation dictates the hydropathy of an amino acid. Hydrophobicity scales include:
 			<a href="https://pubmed.ncbi.nlm.nih.gov/7108955/" target="_blank">
 				Kyte and Doolittle,
 			</a>


### PR DESCRIPTION
## Overview
Edited the info icon pop-up text. Changed hydropathy scales to hydrophobicity scales

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [X] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Associated Issues
- Added a minor edit to https://github.com/BranniganLab/blobulator/pull/729

## To-dos
- [x] change "hydropathy scales" to "hydrophobicity scales" in the info icon box