### PR TITLE
scaling container content based on aspect ratio of viewer

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -131,3 +131,10 @@ td > div {
     height: 10px !important; /* overwrites any other rules */
     background-color: #FFFFFF;
 }
+
+@media (max-width: 767px) {
+    .container {
+        transform: scale(0.7);
+        transform-origin: top left;
+    }
+}


### PR DESCRIPTION
## Overview
Scaling all contents of div.container when aspect ratio of the viewer window matches that of a cellphone

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Associated Issues
- issue #653 

## To-dos
- [x] Adaptively scaling result page container when viewer window matches that of a mobile device