### PR TITLE
zooming out further when mobile device is used

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -134,7 +134,7 @@ td > div {
 
 @media (max-width: 767px) {
     .container {
-        transform: scale(0.7);
+        transform: scale(0.4ßß);
         transform-origin: top left;
     }
 }


### PR DESCRIPTION
## Overview
Modifying the displayed size of the results page elements from 70% to 40% when viewed on a mobile device

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Associated Issues
- Issue #653 
