### PR TITLE
removing px which may be causing mobile site to be reloaded multiple …

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -175,7 +175,7 @@ td > div {
 @media (max-width: 767px) {
     #result {
 		padding: 0;
-		--scale: calc(100vw / 1300px);
+		--scale: calc(100vw / 1300);
 		transform: scale(var(--scale));
 		transform-origin: top left;
     }


### PR DESCRIPTION
…times or slowing down the viewport scaling calculation time

## Overview
One or two sentences briefly summarizing the PR

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Associated Issues
- issue #653 

## To-dos
- [x] Removing the label px for transform scaling factor calculation