### PR TITLE
653 optimize for mobile

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -175,7 +175,9 @@ td > div {
 @media (max-width: 767px) {
     #result {
 		padding: 0;
-		transform: scale(calc(100vw / 1300px));
+		transform:
+			translateZ(0)
+			scale(calc(100vw / 1300px));
 		transform-origin: top left;
 		will-change: transform;
     }

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -175,8 +175,8 @@ td > div {
 @media (max-width: 767px) {
     #result {
 		padding: 0;
-		--scale: calc(100vw / 1300);
-		transform: scale(var(--scale));
+		transform: scale(calc(100vw / 1300px));
 		transform-origin: top left;
+		will-change: transform;
     }
 }


### PR DESCRIPTION
## Overview
Scale calculation is now one line, added will change and no translation along the Z axis

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Associated Issues
- issue #653 

## To-dos
- [x] added translate Z
- [x] added will-change: transform