### PR TITLE
adding check to stop safari from entering reload loop

### DIFF
--- a/website/templates/result.html
+++ b/website/templates/result.html
@@ -471,15 +471,15 @@ $(document).ready( function() {
 
 	function applyScale() {
 		const resultContainer = document.getElementById('result');
+		// Don't apply if already scaled
+		if (resultContainer.dataset.scaled === 'true') return;
+		
 		if (window.innerWidth <= 767) {
 			const scale = window.innerWidth / 1300;
 			resultContainer.style.transform = `scale(${scale})`;
 			resultContainer.style.transformOrigin = 'top left';
-		} else {
-			resultContainer.style.transform = '';
+			resultContainer.dataset.scaled = 'true'; // mark as done
 		}
-		console.log(window.innerWidth)
-	}
 	applyScale();
 });
 


### PR DESCRIPTION
## Overview
Adding check so that scaling only happens once

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Associated Issues
- issue #653 

## To-dos
- [x] Added check to see if scaling has already occured
