### PR TITLE
653 optimize for mobile

### DIFF
--- a/website/static/style.css
+++ b/website/static/style.css
@@ -173,9 +173,6 @@ td > div {
 
 @media (max-width: 767px) {
     #result {
-        padding: 0;
-        transform-origin: top left;
-        overflow: hidden;
         -webkit-overflow-scrolling: auto;
     }
 }

--- a/website/static/style.css
+++ b/website/static/style.css
@@ -171,3 +171,11 @@ td > div {
 	height: 750px;
 }
 
+@media (max-width: 767px) {
+    #result {
+        padding: 0;
+        transform-origin: top left;
+        overflow: hidden;
+        -webkit-overflow-scrolling: auto;
+    }
+}


### PR DESCRIPTION
## Overview
Add webkit overflow scrolling option to style.css

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Associated Issues
- issue #653

## To-dos
- [x] add -webkit-overflow-scrolling: auto to style.css
